### PR TITLE
[DEVLABS-2025] Migrate UI from MUI to ShadCN (Home Page to Overview Dashboard)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
+    "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tailwindcss/vite": "^4.1.11",
     "@testing-library/dom": "^10.4.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.2.5
         version: 1.2.5(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.12
+        version: 1.1.12(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.7
         version: 1.2.7(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1785,6 +1788,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -1814,6 +1830,15 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.10':
@@ -1912,6 +1937,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.10':
+    resolution: {integrity: sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.7':
     resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
     peerDependencies:
@@ -1936,6 +1974,19 @@ packages:
 
   '@radix-ui/react-switch@1.2.5':
     resolution: {integrity: sha512-5ijLkak6ZMylXsaImpZ8u4Rlf5grRmoc0p0QeX9VJtlrM4f5m3nCTX8tWga/zOA8PZYIR/t0p2Mnvd7InrJ6yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.12':
+    resolution: {integrity: sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6829,6 +6880,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.6
 
+  '@radix-ui/react-collection@1.1.7(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.6)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.6
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.6)(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -6859,6 +6921,12 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-remove-scroll: 2.7.1(@types/react@19.1.6)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.6
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.1.6)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.6
 
@@ -6940,6 +7008,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.6
 
+  '@radix-ui/react-roving-focus@1.1.10(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.6)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.6
+
   '@radix-ui/react-separator@1.1.7(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -6964,6 +7048,21 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.6)(react@19.1.0)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.6)(react@19.1.0)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.6
+
+  '@radix-ui/react-tabs@1.1.12(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.6)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from "react";
 import "./App.css";
-import { StyledEngineProvider } from "@mui/material/styles";
-import CssBaseline from "@mui/material/CssBaseline";
 import { Navbar } from "./components/Navbar.jsx";
 import { CodeforcesTable } from "./components/CodeforcesTable.jsx";
 import { CodechefTable } from "./components/CodechefTable";
@@ -83,167 +81,164 @@ function App() {
   }, []);
 
   return (
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider defaultTheme="dark">
-        <CssBaseline />
-        <Router>
-          <AuthProvider>
-            <SidebarProvider>
-              <Navbar />
-              <div className="App">
-                <SidebarTrigger />
-                <Routes>
-                  <Route
-                    exact
-                    path="/register"
-                    element={<Register darkmode={darkmode} />}
-                  />
-                  <Route
-                    exact
-                    path="/login"
-                    element={<Login darkmode={darkmode} />}
-                  />
-                  <Route
-                    exact
-                    path="/leetcoderankingsccps"
-                    element={<LeetcodeRankingsCCPS darkmode={darkmode} />}
-                  />
-                  <Route
-                    exact
-                    path="/"
-                    element={
-                      <PrivateRoute>
-                        <HomePage />
-                      </PrivateRoute>
-                    }
-                  />
-                  <Route
-                    exact
-                    path="/codeforces"
-                    element={
-                      <PrivateRoute>
-                        <CodeforcesTable
-                          darkmode={darkmode}
-                          codeforcesfriends={codeforcesfriends}
-                          setCodeforcesfriends={setCodeforcesfriends}
-                          codeforcesUsers={codeforcesUsers}
-                          cfshowfriends={cfshowfriends}
-                          setCfshowfriends={setCfshowfriends}
-                        />
-                      </PrivateRoute>
-                    }
-                  />
-                  <Route
-                    exact
-                    path="/codechef"
-                    element={
-                      <PrivateRoute>
-                        <CodechefTable
-                          darkmode={darkmode}
-                          codechefUsers={codechefUsers}
-                          codecheffriends={codecheffriends}
-                          setCodecheffriends={setCodecheffriends}
-                          ccshowfriends={ccshowfriends}
-                          setCCshowfriends={setCCshowfriends}
-                        />
-                      </PrivateRoute>
-                    }
-                  />
-                  <Route
-                    exact
-                    path="/openlake"
-                    element={
-                      <PrivateRoute>
-                        <OpenlakeTable
-                          darkmode={darkmode}
-                          codechefUsers={openlakeContributor}
-                          codecheffriends={openlakefriends}
-                          setCodecheffriends={setOpenlakefriends}
-                          ccshowfriends={olshowfriends}
-                          setCCshowfriends={setOlshowfriends}
-                        />
-                      </PrivateRoute>
-                    }
-                  />
-                  <Route
-                    exact
-                    path="/github"
-                    element={
-                      <PrivateRoute>
-                        <GithubTable
-                          darkmode={darkmode}
-                          githubUsers={githubUser}
-                          githubfriends={githubfriends}
-                          setGithubfriends={setGithubfriends}
-                          ghshowfriends={ghshowfriends}
-                          setGHshowfriends={setGhshowfriends}
-                        />
-                      </PrivateRoute>
-                    }
-                  />
-                  <Route
-                    exact
-                    path="/leetcode"
-                    element={
-                      <PrivateRoute>
-                        <LeetcodeTable
-                          darkmode={darkmode}
-                          leetcodeUsers={leetcodeUsers}
-                          leetcodefriends={leetcodefriends}
-                          setLeetcodefriends={setLeetcodefriends}
-                          ltshowfriends={ltshowfriends}
-                          setLTshowfriends={setLtshowfriends}
-                        />
-                      </PrivateRoute>
-                    }
-                  />
-                  <Route
-                    exact
-                    path="/profile"
-                    element={
-                      <PrivateRoute>
-                        <Profile darkmode={darkmode} />-
-                      </PrivateRoute>
-                    }
-                  />
-                  <Route
-                    exact
-                    path="/leetcoderankings"
-                    element={
-                      <PrivateRoute>
-                        <LeetcodeRankings darkmode={darkmode} />
-                      </PrivateRoute>
-                    }
-                  />
-                  <Route
-                    exact
-                    path="/leetcoderanking/:username"
-                    element={
-                      <PrivateRoute>
-                        <LeetcodeGraphs darkmode={darkmode} />
-                      </PrivateRoute>
-                    }
-                  />
-                  <Route
-                    exact
-                    path="/dashboard"
-                    element={
-                      <PrivateRoute>
-                        <Dashboard />
-                      </PrivateRoute>
-                    }
-                  />
-                  {/* <Route exact path="/leetcoderankingccps" element={<PrivateRoute><LeetcodeRankingsCCPS darkmode={darkmode} /></PrivateRoute>} /> */}
-                  <Route exact path="/*" element={<HomePage />} />
-                </Routes>
-                <GoToTop />
-                <Footer />
-              </div>
-            </SidebarProvider>
-          </AuthProvider>
-        </Router>
-      </ThemeProvider>
-    </StyledEngineProvider>
+    <ThemeProvider defaultTheme="dark">
+      <Router>
+        <AuthProvider>
+          <SidebarProvider>
+            <Navbar />
+            <div className="App bg-background">
+              <SidebarTrigger className="text-foreground" />
+              <Routes>
+                <Route
+                  exact
+                  path="/register"
+                  element={<Register darkmode={darkmode} />}
+                />
+                <Route
+                  exact
+                  path="/login"
+                  element={<Login darkmode={darkmode} />}
+                />
+                <Route
+                  exact
+                  path="/leetcoderankingsccps"
+                  element={<LeetcodeRankingsCCPS darkmode={darkmode} />}
+                />
+                <Route
+                  exact
+                  path="/"
+                  element={
+                    <PrivateRoute>
+                      <HomePage />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  exact
+                  path="/codeforces"
+                  element={
+                    <PrivateRoute>
+                      <CodeforcesTable
+                        darkmode={darkmode}
+                        codeforcesfriends={codeforcesfriends}
+                        setCodeforcesfriends={setCodeforcesfriends}
+                        codeforcesUsers={codeforcesUsers}
+                        cfshowfriends={cfshowfriends}
+                        setCfshowfriends={setCfshowfriends}
+                      />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  exact
+                  path="/codechef"
+                  element={
+                    <PrivateRoute>
+                      <CodechefTable
+                        darkmode={darkmode}
+                        codechefUsers={codechefUsers}
+                        codecheffriends={codecheffriends}
+                        setCodecheffriends={setCodecheffriends}
+                        ccshowfriends={ccshowfriends}
+                        setCCshowfriends={setCCshowfriends}
+                      />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  exact
+                  path="/openlake"
+                  element={
+                    <PrivateRoute>
+                      <OpenlakeTable
+                        darkmode={darkmode}
+                        codechefUsers={openlakeContributor}
+                        codecheffriends={openlakefriends}
+                        setCodecheffriends={setOpenlakefriends}
+                        ccshowfriends={olshowfriends}
+                        setCCshowfriends={setOlshowfriends}
+                      />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  exact
+                  path="/github"
+                  element={
+                    <PrivateRoute>
+                      <GithubTable
+                        darkmode={darkmode}
+                        githubUsers={githubUser}
+                        githubfriends={githubfriends}
+                        setGithubfriends={setGithubfriends}
+                        ghshowfriends={ghshowfriends}
+                        setGHshowfriends={setGhshowfriends}
+                      />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  exact
+                  path="/leetcode"
+                  element={
+                    <PrivateRoute>
+                      <LeetcodeTable
+                        darkmode={darkmode}
+                        leetcodeUsers={leetcodeUsers}
+                        leetcodefriends={leetcodefriends}
+                        setLeetcodefriends={setLeetcodefriends}
+                        ltshowfriends={ltshowfriends}
+                        setLTshowfriends={setLtshowfriends}
+                      />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  exact
+                  path="/profile"
+                  element={
+                    <PrivateRoute>
+                      <Profile darkmode={darkmode} />-
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  exact
+                  path="/leetcoderankings"
+                  element={
+                    <PrivateRoute>
+                      <LeetcodeRankings darkmode={darkmode} />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  exact
+                  path="/leetcoderanking/:username"
+                  element={
+                    <PrivateRoute>
+                      <LeetcodeGraphs darkmode={darkmode} />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  exact
+                  path="/dashboard"
+                  element={
+                    <PrivateRoute>
+                      <Dashboard />
+                    </PrivateRoute>
+                  }
+                />
+                {/* <Route exact path="/leetcoderankingccps" element={<PrivateRoute><LeetcodeRankingsCCPS darkmode={darkmode} /></PrivateRoute>} /> */}
+                <Route exact path="/*" element={<HomePage />} />
+              </Routes>
+              <GoToTop />
+              <Footer />
+            </div>
+          </SidebarProvider>
+        </AuthProvider>
+      </Router>
+    </ThemeProvider>
   );
 }
 export default App;

--- a/app/src/components/HomePage.jsx
+++ b/app/src/components/HomePage.jsx
@@ -1,21 +1,112 @@
 import { useSidebar } from "@/components/ui/sidebar";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Trophy,
+  Code2,
+  Target,
+  GitBranch,
+  ArrowDownRight,
+  ArrowUpRight,
+} from "lucide-react";
+import { useAuth } from "@/Context/AuthContext";
+var rank = 0;
+
+function Cards(usernames) {
+  usernames = usernames.usernames;
+  var CardInfo = [
+    {
+      title: "Overall Rank",
+      icon: Trophy,
+      info: `#${rank}`,
+      change: 100,
+      suffix: "Among all users",
+    },
+    {
+      title: "Codeforces Rating",
+      icon: Code2,
+      info: `${usernames.codeforces.rating}`,
+      change: 100,
+      suffix: "Title",
+    },
+    {
+      title: "LeetCode Problems",
+      icon: Target,
+      info: `${usernames.leetcode.total_solved}`,
+      change: -100,
+      suffix: "This month",
+    },
+    {
+      title: "Github Contributions",
+      icon: GitBranch,
+      info: `${usernames.github.contributions}`,
+      change: 100,
+      suffix: "This year",
+    },
+  ];
+  return (
+    <div className="col-span-full grid grid-cols-2 gap-4 lg:grid-cols-4">
+      {CardInfo.map((info) => (
+        <Card
+          id="codeforces"
+          className="w-[100%]"
+          key={info.title.split(" ")[0].toLowerCase()}
+        >
+          <CardHeader>
+            {info.title}
+            <CardAction>
+              <info.icon />
+            </CardAction>
+          </CardHeader>
+          <CardContent>
+            <CardTitle>{info.info}</CardTitle>
+          </CardContent>
+          <CardFooter>
+            <CardDescription>
+              <span
+                className={`text-${info.change > 0 ? "green" : "red"}-600`}
+              >
+                {info.change > 0 ? (
+                  <>
+                    <ArrowUpRight className="inline-flex w-4" />+
+                  </>
+                ) : (
+                  <ArrowDownRight className="inline-flex w-4" />
+                )}
+                {info.change}
+              </span>{" "}
+              {info.suffix}
+            </CardDescription>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}
 const HomePage = () => {
   const { open, isMobile } = useSidebar();
+  const { userNames } = useAuth();
   return (
     <div
+      className="text-foreground flex h-[100%] flex-col gap-5 px-10"
       style={{
-        textAlign: "center",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
         width:
           open && !isMobile
             ? "calc(100vw - var(--sidebar-width))"
             : "100vw",
       }}
     >
-      <h1>LeaderBoard-Pro</h1>
-      <h3>A Project Under OpenLake</h3>
+      <div className="text-3xl font-semibold">
+        Welcome back, {userNames.username}
+      </div>
+      <Cards usernames={userNames} />
     </div>
   );
 };

--- a/app/src/components/ui/card.jsx
+++ b/app/src/components/ui/card.jsx
@@ -1,0 +1,101 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CardHeader({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CardTitle({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props} />
+  );
+}
+
+function CardDescription({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props} />
+  );
+}
+
+function CardAction({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CardContent({
+  className,
+  ...props
+}) {
+  return (<div data-slot="card-content" className={cn("px-6", className)} {...props} />);
+}
+
+function CardFooter({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props} />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/app/src/components/ui/tabs.jsx
+++ b/app/src/components/ui/tabs.jsx
@@ -1,0 +1,60 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props} />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props} />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
## Purpose ✨
This PR intends to migrate the current basic homepage to a dashboard giving the user an overview of their current position with regards to their peers and their previous selves, highlighting their improvements in respective competitve programming sites as well as Github contributions. Part of #132.

## Details 📝

- <!--- Update 1 ---> Fixed some code in the main App.jsx to make it seem better in dark mode for ease of work in future
- <!--- Update 2 ---> Added a dashboard interface with cards showing improvements and current position of the user across different sites.

## Dependencies 🔗

None

## Current Issues 🔭

- [ ] The Cards component has no check to see whether the usernames of each of the corresponding site is present or not, which might crash the site
- [ ] The dashboard component height is currently having issues due to the sidebar toggle button, which will be migrated to a different component later on.

<!--- Mention any improvements to be done in future related to any file/feature. If you believe that there are no further improvements, write None --->

## Mentions 👀
@amaydixit11 
<!--- Mention and tag the people. Type '@' and you will automatically get suggestions. Usually the mentions are for the person(s) by whom you wanted your PR to get reviewed. --->

## Screenshots of relevant screens 📸

- ### With sidebar expanded<img width="1851" height="1115" alt="image" src="https://github.com/user-attachments/assets/5f98920b-56e4-4bf2-9fae-039b57abfedd" />
- ### With sidebar closed<img width="1851" height="1115" alt="image" src="https://github.com/user-attachments/assets/f5ee4558-c4f1-49d4-948f-a26818a2da8d" />
- ### Light Mode<img width="1851" height="1115" alt="image" src="https://github.com/user-attachments/assets/e56aee7e-45d1-49eb-ad53-37016f72daab" />
- ### Responsive design for smaller screen<img width="891" height="987" alt="image" src="https://github.com/user-attachments/assets/8c27a5db-b7f9-485b-adc6-3bb53bbc196d" />

