### PR TITLE
[DEVLABS-2025] Migrate Footer and make a new NavMenu/top bar.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-navigation-menu": "^1.2.13",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
     "@mui/system": "^7.1.0",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-navigation-menu": "^1.2.13",
     "@radix-ui/react-separator": "^1.1.7",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-navigation-menu':
+        specifier: ^1.2.13
+        version: 1.2.13(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-separator':
         specifier: ^1.1.7
         version: 1.1.7(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1883,6 +1886,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.13':
+    resolution: {integrity: sha512-WG8wWfDiJlSF5hELjwfjSGOXcBR/ZMhBFCGYe8vERpC39CQYZeq1PQ2kaYHdye3V95d06H89KGMsVCIE4LWo3g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popper@1.2.7':
@@ -6962,6 +6978,27 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.6)(react@19.1.0)
       react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.6
+
+  '@radix-ui/react-navigation-menu@1.2.13(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.6
 

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@nivo/line':
         specifier: ^0.99.0
         version: 0.99.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1791,6 +1794,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -2056,6 +2072,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4694,6 +4719,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vite-plugin-eslint@1.8.1:
     resolution: {integrity: sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==}
     peerDependencies:
@@ -6896,6 +6926,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.6
 
+  '@radix-ui/react-avatar@1.1.10(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.6
+
   '@radix-ui/react-collection@1.1.7(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.6)(react@19.1.0)
@@ -7149,6 +7191,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.6)(react@19.1.0)
       react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.6
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.1.6)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.6
 
@@ -10010,6 +10059,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.6
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   vite-plugin-eslint@1.8.1(eslint@9.29.0(jiti@2.4.2))(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(yaml@2.8.0)):
     dependencies:

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -24,6 +24,7 @@ import {
   SidebarTrigger,
 } from "./components/ui/sidebar.jsx";
 import { ThemeProvider } from "@/Context/ThemeProvider.jsx";
+import { NavMenu } from "./components/NavMenu";
 const BACKEND = import.meta.env.VITE_BACKEND;
 function App() {
   const [codechefUsers, setCodechefUsers] = useState([]);
@@ -87,7 +88,7 @@ function App() {
           <SidebarProvider>
             <Navbar />
             <div className="App bg-background">
-              <SidebarTrigger className="text-foreground" />
+              <NavMenu />
               <Routes>
                 <Route
                   exact

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -87,7 +87,7 @@ function App() {
         <AuthProvider>
           <SidebarProvider>
             <Navbar />
-            <div className="App bg-background">
+            <div className="App bg-background w-full">
               <NavMenu />
               <Routes>
                 <Route

--- a/app/src/components/Footer.jsx
+++ b/app/src/components/Footer.jsx
@@ -1,42 +1,15 @@
-import Link from "@mui/material/Link";
-import Typography from "@mui/material/Typography";
+import { Button } from "@/components/ui/button";
 
 const Footer = () => {
-  function Copyright(props) {
-    return (
-      <Typography
-        variant="body2"
-        color="text.secondary"
-        align="center"
-        style={{ color: "white" }}
-        {...props}
-      >
-        {"Copyright © "}
-        <Link
-          color="inherit"
-          href="https://github.com/OpenLake/Leaderboard-Pro/"
-        >
-          LeaderBoard-Pro
-        </Link>{" "}
-        {new Date().getFullYear()}
-        {"."}
-      </Typography>
-    );
-  }
-
   return (
-    <div
-      style={{
-        backgroundColor: "#1976d2",
-        padding: "0.5rem",
-        color: "white",
-        position: "fixed",
-        bottom: 0, // Align to the bottom
-        left: 0, // Optional, align to the left
-        right: 0, // Optional, align to the right
-      }}
-    >
-      <Copyright />
+    <div className="text-foreground bg-accent flex h-8 justify-center">
+      <span>Copyright ©</span>
+      <Button variant="link" className="h-fit px-2 py-0.5" asChild>
+        <a href="https://github.com/OpenLake/Leaderboard-Pro/">
+          LeaderBoard-Pro
+        </a>
+      </Button>
+      {`${new Date().getFullYear().toString()}.`}
     </div>
   );
 };

--- a/app/src/components/NavMenu.jsx
+++ b/app/src/components/NavMenu.jsx
@@ -1,0 +1,64 @@
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  NavigationMenuViewport,
+} from "@/components/ui/navigation-menu";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Input } from "@/components/ui/input";
+import { useTheme } from "@/Context/ThemeProvider";
+import { Switch } from "@/components/ui/switch";
+import { Sun, Moon } from "lucide-react";
+import { Button } from "./ui/button";
+import { cn } from "@/lib/utils";
+
+export function NavMenu() {
+  const { setTheme, theme } = useTheme();
+  return (
+    <NavigationMenu className="grid-row m-1 max-w-full border-b-1 pb-3">
+      <div className="grid w-full grid-cols-5 grid-rows-1 gap-10">
+        <div className={"col-start-1 col-end-3 grid"}>
+          <NavigationMenuList className="justify-start">
+            <NavigationMenuItem asChild>
+              <SidebarTrigger className="text-foreground mr-4" />
+            </NavigationMenuItem>
+            <NavigationMenuItem className={"ml-auto flex grow"}>
+              <Input
+                className="w-full"
+                placeholder="Search users, contests, problems..."
+              ></Input>
+            </NavigationMenuItem>
+          </NavigationMenuList>
+        </div>
+        <div className={"col-start-5 col-end-6 justify-end"}>
+          <NavigationMenuList className="justify-end">
+            <NavigationMenuItem className="flex flex-row gap-1" asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="rounded-full"
+                onClick={() => {
+                  if (theme == "light") setTheme("dark");
+                  else setTheme("light");
+                }}
+              >
+                {theme == "dark" ? (
+                  <Sun className="h-5 w-5" />
+                ) : (
+                  <Moon className="h-5 w-5" />
+                )}
+              </Button>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <NavigationMenuLink>Avatar</NavigationMenuLink>
+            </NavigationMenuItem>
+          </NavigationMenuList>
+        </div>
+      </div>
+    </NavigationMenu>
+  );
+}

--- a/app/src/components/NavMenu.jsx
+++ b/app/src/components/NavMenu.jsx
@@ -8,20 +8,36 @@ import {
   NavigationMenuTrigger,
   NavigationMenuViewport,
 } from "@/components/ui/navigation-menu";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import { Link } from "react-router-dom";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Input } from "@/components/ui/input";
 import { useTheme } from "@/Context/ThemeProvider";
-import { Switch } from "@/components/ui/switch";
+import { useAuth } from "@/Context/AuthContext";
 import { Sun, Moon } from "lucide-react";
 import { Button } from "./ui/button";
-import { cn } from "@/lib/utils";
+function LetterAvatar({ name }) {
+  // just a placeholder for now, but will be used if no user-provided avatar.
+  const initials = name[0].toUpperCase();
+  return (
+    <div className="text-foreground m-auto flex justify-center text-xl font-semibold">
+      {initials}
+    </div>
+  );
+}
 
 export function NavMenu() {
   const { setTheme, theme } = useTheme();
+  const { userNames } = useAuth();
+
   return (
     <NavigationMenu className="grid-row m-1 max-w-full border-b-1 pb-3">
       <div className="grid w-full grid-cols-5 grid-rows-1 gap-10">
-        <div className={"col-start-1 col-end-3 grid"}>
+        <div className={"col-start-1 col-end-3 my-2"}>
           <NavigationMenuList className="justify-start">
             <NavigationMenuItem asChild>
               <SidebarTrigger className="text-foreground mr-4" />
@@ -34,7 +50,7 @@ export function NavMenu() {
             </NavigationMenuItem>
           </NavigationMenuList>
         </div>
-        <div className={"col-start-5 col-end-6 justify-end"}>
+        <div className={"col-start-5 col-end-6"}>
           <NavigationMenuList className="justify-end">
             <NavigationMenuItem className="flex flex-row gap-1" asChild>
               <Button
@@ -54,7 +70,15 @@ export function NavMenu() {
               </Button>
             </NavigationMenuItem>
             <NavigationMenuItem>
-              <NavigationMenuLink>Avatar</NavigationMenuLink>
+              <NavigationMenuLink asChild className="rounded-full">
+                <Link to="/profile" className="rounded-full">
+                  <Avatar className="bg-accent size-9">
+                    <LetterAvatar name={userNames.username} />
+                    {/* <AvatarImage src="https://github.com/shadcn.png" /> */}
+                    {/* <AvatarFallback>CN</AvatarFallback> */}
+                  </Avatar>
+                </Link>
+              </NavigationMenuLink>
             </NavigationMenuItem>
           </NavigationMenuList>
         </div>

--- a/app/src/components/Navbar.jsx
+++ b/app/src/components/Navbar.jsx
@@ -57,7 +57,6 @@ const items = [
     url: "/",
     icon: Award,
   },
-  { title: "Profile", url: "profile", icon: User },
 ];
 const links = ["Openlake", "Github", "LeetCode", "Codeforces", "Codechef"];
 export const Navbar = () => {
@@ -68,18 +67,6 @@ export const Navbar = () => {
     <Sidebar>
       <SidebarHeader className="flex-row justify-between">
         Leaderboard Pro
-        <div className="flex flex-row gap-1">
-          <Sun className="h-5 w-5" />
-          <Switch
-            className="h-5"
-            checked={theme == "dark"}
-            onCheckedChange={(val) => {
-              if (val) setTheme("dark");
-              else setTheme("light");
-            }}
-          />
-          <Moon className="h-5 w-5" />
-        </div>
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>

--- a/app/src/components/ui/avatar.jsx
+++ b/app/src/components/ui/avatar.jsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  ...props
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn("relative flex size-8 shrink-0 overflow-hidden rounded-full", className)}
+      {...props} />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props} />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted flex size-full items-center justify-center rounded-full",
+        className
+      )}
+      {...props} />
+  );
+}
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/app/src/components/ui/navigation-menu.jsx
+++ b/app/src/components/ui/navigation-menu.jsx
@@ -1,0 +1,144 @@
+import * as React from "react";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDownIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function NavigationMenu({
+  className,
+  children,
+  viewport = true,
+  ...props
+}) {
+  return (
+    <NavigationMenuPrimitive.Root
+      data-slot="navigation-menu"
+      data-viewport={viewport}
+      className={cn(
+        "group/navigation-menu relative flex max-w-max flex-1",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {viewport && <NavigationMenuViewport />}
+    </NavigationMenuPrimitive.Root>
+  );
+}
+
+function NavigationMenuList({ className, ...props }) {
+  return (
+    <NavigationMenuPrimitive.List
+      data-slot="navigation-menu-list"
+      className={cn(
+        "group flex flex-1 list-none items-center justify-center gap-1",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NavigationMenuItem({ className, ...props }) {
+  return (
+    <NavigationMenuPrimitive.Item
+      data-slot="navigation-menu-item"
+      className={cn("relative", className)}
+      {...props}
+    />
+  );
+}
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1",
+);
+
+function NavigationMenuTrigger({ className, children, ...props }) {
+  return (
+    <NavigationMenuPrimitive.Trigger
+      data-slot="navigation-menu-trigger"
+      className={cn(navigationMenuTriggerStyle(), "group", className)}
+      {...props}
+    >
+      {children}{" "}
+      <ChevronDownIcon
+        className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
+        aria-hidden="true"
+      />
+    </NavigationMenuPrimitive.Trigger>
+  );
+}
+
+function NavigationMenuContent({ className, ...props }) {
+  return (
+    <NavigationMenuPrimitive.Content
+      data-slot="navigation-menu-content"
+      className={cn(
+        "data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
+        "group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NavigationMenuViewport({ className, ...props }) {
+  return (
+    <div
+      className={cn(
+        "absolute top-full left-0 isolate z-50 flex justify-center",
+      )}
+    >
+      <NavigationMenuPrimitive.Viewport
+        data-slot="navigation-menu-viewport"
+        className={cn(
+          "origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--radix-navigation-menu-viewport-width)]",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function NavigationMenuLink({ className, ...props }) {
+  return (
+    <NavigationMenuPrimitive.Link
+      data-slot="navigation-menu-link"
+      className={cn(
+        "data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NavigationMenuIndicator({ className, ...props }) {
+  return (
+    <NavigationMenuPrimitive.Indicator
+      data-slot="navigation-menu-indicator"
+      className={cn(
+        "data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden",
+        className,
+      )}
+      {...props}
+    >
+      <div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
+    </NavigationMenuPrimitive.Indicator>
+  );
+}
+
+export {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuContent,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+  NavigationMenuIndicator,
+  NavigationMenuViewport,
+  navigationMenuTriggerStyle,
+};


### PR DESCRIPTION
## Purpose ✨

This PR intends to migrate the Footer copyright component to ShadCN components from MUI. It also adds a new top bar or NavMenu for Dark mode toggle, Sidebar Toggle, Search area as well as Avatar based Profile link. The profile link is moved from the Sidebar to the NavMenu.

## Details 📝

<!--- Mention the details. If the details sections is large enough, then mention the details in bullets as follows: --->

- Migrate the Footer from MUI to ShadCN
- Add a NavMenu/Top Bar containing Dark mode toggle, Sidebar Toggle, Search area as well as Avatar based Profile link.

## Future Improvements 🔭
- The Avatar based profile link might be converted into a Popover menu to contain settings and other stuff related to the user.
-  Currently, the avatar shows the username's first Letter as an avatar, which might be later changed to show user-provided avatars too.

## Mentions 👀
@amaydixit11 
<!--- Mention and tag the people. Type '@' and you will automatically get suggestions. Usually the mentions are for the person(s) by whom you wanted your PR to get reviewed. --->

## Screenshots of relevant screens 📸
- ### Dark Mode<img width="1851" height="1083" alt="image" src="https://github.com/user-attachments/assets/802d2d52-087c-4946-be42-64371631882d" />
- ### Light Mode<img width="1851" height="1211" alt="image" src="https://github.com/user-attachments/assets/b4e32142-9e3d-413a-80e3-b78cb30ff1cd" />
