### PR TITLE
[DEVLABS-2025] Migrate from Material UI to ShadCN (OpenLake Table)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tailwindcss/vite": "^4.1.11",
+    "@tanstack/react-table": "^8.21.3",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.1.11(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(yaml@2.8.0))
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -2483,6 +2486,17 @@ packages:
     resolution: {integrity: sha512-RHYhrR3hku0MJFRV+fN2gNbDNEh3dwKvY8XJvTxCSXeMOsCRSr+uKvDWQcbizrHgjML6ZmTE5OwMrl5wKcujCw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -7632,6 +7646,14 @@ snapshots:
       '@tailwindcss/oxide': 4.1.11
       tailwindcss: 4.1.11
       vite: 7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(yaml@2.8.0)
+
+  '@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -6,7 +6,7 @@ import { CodechefTable } from "./components/CodechefTable";
 import { GithubTable } from "./components/GithubTable";
 import Profile from "./components/Profile.jsx";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
-import { OpenlakeTable } from "./components/OpenlakeTable";
+import { OpenlakeTable, OLTable } from "./components/OpenlakeTable";
 import Login from "./components/Login";
 import HomePage from "./components/HomePage";
 import Register from "./components/Register";
@@ -151,14 +151,15 @@ function App() {
                   path="/openlake"
                   element={
                     <PrivateRoute>
-                      <OpenlakeTable
+                      {/* <OpenlakeTable
                         darkmode={darkmode}
                         codechefUsers={openlakeContributor}
                         codecheffriends={openlakefriends}
                         setCodecheffriends={setOpenlakefriends}
                         ccshowfriends={olshowfriends}
                         setCCshowfriends={setOlshowfriends}
-                      />
+                      /> */}
+                      <OLTable OLUsers={openlakeContributor} />
                     </PrivateRoute>
                   }
                 />

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -6,7 +6,7 @@ import { CodechefTable } from "./components/CodechefTable";
 import { GithubTable } from "./components/GithubTable";
 import Profile from "./components/Profile.jsx";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
-import { OpenlakeTable, OLTable } from "./components/OpenlakeTable";
+import { OpenLakeTable } from "./components/OpenlakeTable";
 import Login from "./components/Login";
 import HomePage from "./components/HomePage";
 import Register from "./components/Register";
@@ -19,10 +19,7 @@ import LeetcodeRankingsCCPS from "./components/LeetcodeRankingsCCPS";
 import LeetcodeGraphs from "./components/LeetcodeGraphs";
 import { AuthProvider } from "./Context/AuthContext.jsx";
 import Dashboard from "./components/discussion-forum/dashboard.jsx";
-import {
-  SidebarProvider,
-  SidebarTrigger,
-} from "./components/ui/sidebar.jsx";
+import { SidebarProvider } from "./components/ui/sidebar.jsx";
 import { ThemeProvider } from "@/Context/ThemeProvider.jsx";
 import { NavMenu } from "./components/NavMenu";
 const BACKEND = import.meta.env.VITE_BACKEND;
@@ -41,8 +38,6 @@ function App() {
   const [leetcodefriends, setLeetcodefriends] = useState([]);
   const [githubfriends, setGithubfriends] = useState([]);
   const [ghshowfriends, setGhshowfriends] = useState(false);
-  const [openlakefriends, setOpenlakefriends] = useState([]);
-  const [olshowfriends, setOlshowfriends] = useState(false);
   useEffect(() => {
     fetch(BACKEND + "/codeforces/")
       .then((res) => res.json())
@@ -151,15 +146,7 @@ function App() {
                   path="/openlake"
                   element={
                     <PrivateRoute>
-                      {/* <OpenlakeTable
-                        darkmode={darkmode}
-                        codechefUsers={openlakeContributor}
-                        codecheffriends={openlakefriends}
-                        setCodecheffriends={setOpenlakefriends}
-                        ccshowfriends={olshowfriends}
-                        setCCshowfriends={setOlshowfriends}
-                      /> */}
-                      <OLTable OLUsers={openlakeContributor} />
+                      <OpenLakeTable OLUsers={openlakeContributor} />
                     </PrivateRoute>
                   }
                 />

--- a/app/src/components/OpenlakeTable.jsx
+++ b/app/src/components/OpenlakeTable.jsx
@@ -19,6 +19,7 @@ import { Button as NewButton } from "@/components/ui/button";
 import useScreenWidth from "../hooks/useScreeWidth";
 import { useSidebar } from "@/components/ui/sidebar";
 import { DataTable } from "./ui/data-table";
+import { Input } from "@/components/ui/input";
 
 const PREFIX = "OpenlakeTable";
 
@@ -214,6 +215,20 @@ export function OLTable({ OLUsers }) {
             : "100vw",
       }}
     >
+      <div className="flex flex-row justify-between p-0">
+        <Input
+          placeholder="Search OpenLake contributors..."
+          className="mb-2 w-[40%]"
+          onChange={(val) => setSearchfield(val.target.value)}
+          type="search"
+        />
+        <NewButton
+          variant="secondary"
+          onClick={() => setShowOLFriends(!showOLFriends)}
+        >
+          {showOLFriends ? "Show all users" : "Show friends"}
+        </NewButton>
+      </div>
       <DataTable data={filteredusers} columns={columns} />
     </div>
   );

--- a/app/src/components/OpenlakeTable.jsx
+++ b/app/src/components/OpenlakeTable.jsx
@@ -1,70 +1,12 @@
-import { styled } from "@mui/material/styles";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  Link,
-} from "@mui/material";
-import TextField from "@mui/material/TextField";
-import SearchIcon from "@mui/icons-material/Search";
-import InputAdornment from "@mui/material/InputAdornment";
 import { useEffect, useState } from "react";
-import ToggleButton from "@mui/material/ToggleButton";
-import Button from "@mui/material/Button";
-import { Button as NewButton } from "@/components/ui/button";
-import useScreenWidth from "../hooks/useScreeWidth";
+import { Button } from "@/components/ui/button";
 import { useSidebar } from "@/components/ui/sidebar";
 import { DataTable } from "./ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Switch } from "./ui/switch";
 
-const PREFIX = "OpenlakeTable";
-
-const classes = {
-  root: `${PREFIX}-root`,
-  table: `${PREFIX}-table`,
-  table_dark: `${PREFIX}-table_dark`,
-  medium_page: `${PREFIX}-medium_page`,
-  large_page: `${PREFIX}-large_page`,
-};
-
-const Root = styled("div")({
-  [`& .${classes.table}`]: {
-    minWidth: 500,
-  },
-  [`& .${classes.table_dark}`]: {
-    minWidth: 500,
-    backgroundColor: "Black",
-    border: "2px solid White",
-    borderRadius: "10px",
-  },
-  [`& .${classes.medium_page}`]: {
-    display: "flex",
-    justifyContent: "space-around",
-    flexDirection: "column-reverse",
-    paddingLeft: "2.5vw",
-    paddingRight: "2.5vw",
-    marginTop: "9vh",
-    width: "100vw",
-    flexShrink: "0",
-  },
-  [`& .${classes.large_page}`]: {
-    display: "flex",
-    justifyContent: "space-around",
-    flexDirection: "row",
-    padding: "auto",
-    marginTop: "10vh",
-    width: "99vw",
-    flexShrink: "0",
-  },
-});
-
 const BACKEND = import.meta.env.VITE_BACKEND;
-export function OLTable({ OLUsers }) {
+export function OpenLakeTable({ OLUsers }) {
   const [searchfield, setSearchfield] = useState("");
   const [filteredusers, setFilteredusers] = useState([]);
   const [todisplayusers, setTodisplayusers] = useState([]);
@@ -78,7 +20,7 @@ export function OLTable({ OLUsers }) {
       cell: ({ row }) => {
         const username = row.getValue("username");
         return (
-          <NewButton variant="link" asChild>
+          <Button variant="link" asChild>
             <a
               href={`https://github.com/${username}`}
               target="_blank"
@@ -86,7 +28,7 @@ export function OLTable({ OLUsers }) {
             >
               {username}
             </a>
-          </NewButton>
+          </Button>
         );
       },
     },
@@ -101,19 +43,19 @@ export function OLTable({ OLUsers }) {
         return (
           <div className="flex justify-end">
             {OLFriends.includes(username) ? (
-              <NewButton
+              <Button
                 variant="secondary"
                 onClick={() => dropfriend(username)}
               >
                 Remove Friend
-              </NewButton>
+              </Button>
             ) : (
-              <NewButton
+              <Button
                 variant="secondary"
                 onClick={() => addfriend(username)}
               >
                 Add Friend
-              </NewButton>
+              </Button>
             )}
           </div>
         );
@@ -239,268 +181,3 @@ export function OLTable({ OLUsers }) {
     </div>
   );
 }
-export const OpenlakeTable = ({
-  darkmode,
-  codechefUsers,
-  codecheffriends,
-  setCodecheffriends,
-  ccshowfriends,
-  setCCshowfriends,
-}) => {
-  const [searchfield, setSearchfield] = useState("");
-  const [filteredusers, setFilteredusers] = useState([]);
-  const [todisplayusers, setTodisplayusers] = useState([]);
-  const { open, isMobile } = useSidebar();
-  const getccfriends = async () => {
-    const response = await fetch(BACKEND + "/openlakeFL/", {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Bearer " +
-          JSON.parse(localStorage.getItem("authTokens")).access,
-      },
-    });
-
-    const newData = await response.json();
-    setCodecheffriends(newData);
-  };
-
-  async function addfriend(e) {
-    const response = await fetch(BACKEND + "/openlakeFA/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Bearer " +
-          JSON.parse(localStorage.getItem("authTokens")).access,
-      },
-      body: JSON.stringify({
-        friendName: e.username,
-      }),
-    });
-    if (response.status !== 200) {
-      alert("ERROR!!!!");
-    } else {
-      setCodecheffriends((current) => [...current, e]);
-    }
-  }
-  async function dropfriend(e) {
-    const response = await fetch(BACKEND + "/openlakeFD/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Bearer " +
-          JSON.parse(localStorage.getItem("authTokens")).access,
-      },
-      body: JSON.stringify({
-        friendName: e,
-      }),
-    });
-    if (response.status !== 200) {
-      alert("ERROR!!!!");
-    } else {
-      setCodecheffriends((current) =>
-        current.filter((fruit) => fruit.username !== e),
-      );
-    }
-  }
-  useEffect(() => {
-    getccfriends();
-  }, []);
-
-  useEffect(() => {
-    if (ccshowfriends) {
-      setTodisplayusers(codecheffriends);
-    } else {
-      setTodisplayusers(codechefUsers);
-    }
-    if (searchfield === "") {
-      setFilteredusers(todisplayusers);
-    } else {
-      setFilteredusers(
-        todisplayusers.filter((cfUser) => {
-          return cfUser.username
-            .toLowerCase()
-            .includes(searchfield.toLowerCase());
-        }),
-      );
-    }
-  }, [ccshowfriends, codecheffriends, searchfield, codechefUsers]);
-  useEffect(() => {
-    if (searchfield === "") {
-      setFilteredusers(todisplayusers);
-    } else {
-      setFilteredusers(
-        todisplayusers.filter((cfUser) => {
-          return cfUser.username
-            .toLowerCase()
-            .includes(searchfield.toLowerCase());
-        }),
-      );
-    }
-  }, [searchfield, todisplayusers]);
-
-  const StyledTableCell = TableCell;
-
-  return (
-    <Root
-      className={`openlake ${isMobile ? classes.medium_page : classes.large_page}`}
-    >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          marginTop: "15vh",
-          position: "relative",
-          marginBottom: "10px",
-          alignItems: "center",
-          width:
-            open && !isMobile
-              ? "calc(100vw - var(--sidebar-width))"
-              : "100vw",
-        }}
-      >
-        <TextField
-          id="outlined-basic"
-          label="Search Usernames"
-          variant="outlined"
-          defaultValue=""
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon />
-              </InputAdornment>
-            ),
-          }}
-          onChange={(e) => {
-            setSearchfield(e.target.value);
-          }}
-        />
-        <ToggleButton
-          value="check"
-          selected={ccshowfriends}
-          onChange={() => {
-            setCCshowfriends(!ccshowfriends);
-          }}
-          style={{
-            backgroundColor: darkmode ? "#02055a" : "#2196f3",
-            color: "white",
-            marginTop: isMobile ? "2vh" : "4vh",
-          }}
-        >
-          {ccshowfriends ? "Show All" : "Show Friends"}
-        </ToggleButton>
-        <div
-          style={{
-            marginTop: isMobile ? "2vh" : "4vh",
-          }}
-        >
-          {!filteredusers.length ? (
-            "No users"
-          ) : (
-            <TableContainer component={Paper}>
-              <Table
-                className={darkmode ? classes.table_dark : classes.table}
-                aria-label="openlake-table"
-              >
-                <TableHead>
-                  <TableRow
-                    style={{
-                      backgroundColor: darkmode ? "#1c2e4a " : "#1CA7FC",
-                    }}
-                  >
-                    <StyledTableCell
-                      style={{ textAlign: "center" }}
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Username
-                    </StyledTableCell>
-                    <StyledTableCell
-                      style={{ textAlign: "center" }}
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Contributions
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    ></StyledTableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {filteredusers
-                    .sort((a, b) =>
-                      a.contributions < b.contributions ? 1 : -1,
-                    )
-                    .map((olUser) => (
-                      <TableRow key={olUser.id}>
-                        <StyledTableCell
-                          style={{ textAlign: "center" }}
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          <Link
-                            style={{
-                              fontWeight: "bold",
-                              textDecoration: "none",
-                              color: darkmode ? "#03DAC6" : "",
-                            }}
-                            href={`https://github.com/${olUser.username}`}
-                            target="_blank"
-                          >
-                            {olUser.username}
-                          </Link>
-                        </StyledTableCell>
-                        <StyledTableCell
-                          style={{ textAlign: "center" }}
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          {olUser.contributions}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          <Button
-                            variant="contained"
-                            style={{
-                              backgroundColor: darkmode ? "#146ca4" : "",
-                            }}
-                            onClick={() => {
-                              !codecheffriends.some(
-                                (item) =>
-                                  item.username === olUser.username,
-                              )
-                                ? addfriend(olUser)
-                                : dropfriend(olUser.username);
-                            }}
-                          >
-                            {codecheffriends.some(
-                              (item) => item.username === olUser.username,
-                            )
-                              ? "Remove Friend"
-                              : "Add Friend"}
-                          </Button>
-                        </StyledTableCell>
-                      </TableRow>
-                    ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
-        </div>
-      </div>
-    </Root>
-  );
-};

--- a/app/src/components/OpenlakeTable.jsx
+++ b/app/src/components/OpenlakeTable.jsx
@@ -97,20 +97,24 @@ export function OLTable({ OLUsers }) {
       id: "actions",
       cell: ({ row }) => {
         const username = row.getValue("username");
-        return OLFriends.includes(username) ? (
-          <NewButton
-            variant="secondary"
-            onClick={() => dropfriend(username)}
-          >
-            Remove Friend
-          </NewButton>
-        ) : (
-          <NewButton
-            variant="secondary"
-            onClick={() => addfriend(username)}
-          >
-            Add Friend
-          </NewButton>
+        return (
+          <div className="flex justify-end">
+            {OLFriends.includes(username) ? (
+              <NewButton
+                variant="secondary"
+                onClick={() => dropfriend(username)}
+              >
+                Remove Friend
+              </NewButton>
+            ) : (
+              <NewButton
+                variant="secondary"
+                onClick={() => addfriend(username)}
+              >
+                Add Friend
+              </NewButton>
+            )}
+          </div>
         );
       },
     },

--- a/app/src/components/OpenlakeTable.jsx
+++ b/app/src/components/OpenlakeTable.jsx
@@ -63,7 +63,6 @@ const Root = styled("div")({
 
 const BACKEND = import.meta.env.VITE_BACKEND;
 export function OLTable({ OLUsers }) {
-  console.log(OLUsers);
   const [searchfield, setSearchfield] = useState("");
   const [filteredusers, setFilteredusers] = useState([]);
   const [todisplayusers, setTodisplayusers] = useState([]);
@@ -93,6 +92,27 @@ export function OLTable({ OLUsers }) {
       accessorKey: "contributions",
       header: "Contributions",
     },
+    {
+      id: "actions",
+      cell: ({ row }) => {
+        const username = row.getValue("username");
+        return OLFriends.includes(username) ? (
+          <NewButton
+            variant="secondary"
+            onClick={() => dropfriend(username)}
+          >
+            Remove Friend
+          </NewButton>
+        ) : (
+          <NewButton
+            variant="secondary"
+            onClick={() => addfriend(username)}
+          >
+            Add Friend
+          </NewButton>
+        );
+      },
+    },
   ];
   const getccfriends = async () => {
     const response = await fetch(BACKEND + "/openlakeFL/", {
@@ -119,7 +139,7 @@ export function OLTable({ OLUsers }) {
           JSON.parse(localStorage.getItem("authTokens")).access,
       },
       body: JSON.stringify({
-        friendName: e.username,
+        friendName: e,
       }),
     });
     if (response.status !== 200) {
@@ -170,7 +190,7 @@ export function OLTable({ OLUsers }) {
         }),
       );
     }
-  }, [showOLFriends, OLFriends, searchfield, OLFriends]);
+  }, [showOLFriends, OLFriends, searchfield, OLUsers]);
   useEffect(() => {
     if (searchfield === "") {
       setFilteredusers(todisplayusers);
@@ -194,7 +214,7 @@ export function OLTable({ OLUsers }) {
             : "100vw",
       }}
     >
-      <DataTable data={OLUsers} columns={columns} />
+      <DataTable data={filteredusers} columns={columns} />
     </div>
   );
 }

--- a/app/src/components/OpenlakeTable.jsx
+++ b/app/src/components/OpenlakeTable.jsx
@@ -20,6 +20,7 @@ import useScreenWidth from "../hooks/useScreeWidth";
 import { useSidebar } from "@/components/ui/sidebar";
 import { DataTable } from "./ui/data-table";
 import { Input } from "@/components/ui/input";
+import { Switch } from "./ui/switch";
 
 const PREFIX = "OpenlakeTable";
 
@@ -219,19 +220,20 @@ export function OLTable({ OLUsers }) {
             : "100vw",
       }}
     >
-      <div className="flex flex-row justify-between p-0">
+      <div className="mb-2 flex flex-row justify-between">
         <Input
           placeholder="Search OpenLake contributors..."
-          className="mb-2 w-[40%]"
+          className="w-[40%]"
           onChange={(val) => setSearchfield(val.target.value)}
           type="search"
         />
-        <NewButton
-          variant="secondary"
-          onClick={() => setShowOLFriends(!showOLFriends)}
-        >
-          {showOLFriends ? "Show all users" : "Show friends"}
-        </NewButton>
+        <div>
+          Friends Only
+          <Switch
+            className="mx-1 align-middle"
+            onCheckedChange={(val) => setShowOLFriends(val)}
+          />
+        </div>
       </div>
       <DataTable data={filteredusers} columns={columns} />
     </div>

--- a/app/src/components/ui/data-table.jsx
+++ b/app/src/components/ui/data-table.jsx
@@ -1,0 +1,75 @@
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export function DataTable({ columns, data }) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(
+                      cell.column.columnDef.cell,
+                      cell.getContext(),
+                    )}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell
+                colSpan={columns.length}
+                className="h-24 text-center"
+              >
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/app/src/components/ui/table.jsx
+++ b/app/src/components/ui/table.jsx
@@ -1,0 +1,121 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({
+  className,
+  ...props
+}) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props} />
+    </div>
+  );
+}
+
+function TableHeader({
+  className,
+  ...props
+}) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props} />
+  );
+}
+
+function TableBody({
+  className,
+  ...props
+}) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props} />
+  );
+}
+
+function TableFooter({
+  className,
+  ...props
+}) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
+      {...props} />
+  );
+}
+
+function TableRow({
+  className,
+  ...props
+}) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TableHead({
+  className,
+  ...props
+}) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TableCell({
+  className,
+  ...props
+}) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props} />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
## Purpose ✨

This PR intends to migrate the Openlake table from the current Material UI component library to ShadCN. Relates to #132 
## Details 📝

<!--- Mention the details. If the details sections is large enough, then mention the details in bullets as follows: --->

- Make a new leaderboard table component based on the DataTable component of ShadCN using Tanstack Table.

## Dependencies 🔗
- `pnpm` -> `@tanstack/react-table`

## Future Improvements 🔭
None

## Mentions 👀
@amaydixit11 
<!--- Mention and tag the people. Type '@' and you will automatically get suggestions. Usually the mentions are for the person(s) by whom you wanted your PR to get reviewed. --->

## Screenshots of relevant screens 📸
- ### Dark Mode<img width="1851" height="902" alt="image" src="https://github.com/user-attachments/assets/37aaf954-b7cc-46da-bab3-e04ca86dc164" />
- ### Light Mode<img width="1851" height="902" alt="image" src="https://github.com/user-attachments/assets/d596f9a3-61b3-413b-b48e-8d9e82d8d597" />
