### PR TITLE
[DEVLABS-2025] Migrate from Material UI to ShadCN (GithubTable to GH table)

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -3,7 +3,7 @@ import "./App.css";
 import { Navbar } from "./components/Navbar.jsx";
 import { CodeforcesTable } from "./components/CodeforcesTable.jsx";
 import { CodechefTable } from "./components/CodechefTable";
-import { GithubTable, GHTable } from "./components/GithubTable";
+import { GHTable } from "./components/GithubTable";
 import Profile from "./components/Profile.jsx";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { OpenLakeTable } from "./components/OpenlakeTable";
@@ -36,8 +36,6 @@ function App() {
   const [codecheffriends, setCodecheffriends] = useState([]);
   const [ltshowfriends, setLtshowfriends] = useState(false);
   const [leetcodefriends, setLeetcodefriends] = useState([]);
-  const [githubfriends, setGithubfriends] = useState([]);
-  const [ghshowfriends, setGhshowfriends] = useState(false);
   useEffect(() => {
     fetch(BACKEND + "/codeforces/")
       .then((res) => res.json())
@@ -155,14 +153,6 @@ function App() {
                   path="/github"
                   element={
                     <PrivateRoute>
-                      {/* <GithubTable
-                        darkmode={darkmode}
-                        githubUsers={githubUser}
-                        githubfriends={githubfriends}
-                        setGithubfriends={setGithubfriends}
-                        ghshowfriends={ghshowfriends}
-                        setGHshowfriends={setGhshowfriends}
-                      /> */}
                       <GHTable githubUsers={githubUser} />
                     </PrivateRoute>
                   }

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -3,7 +3,7 @@ import "./App.css";
 import { Navbar } from "./components/Navbar.jsx";
 import { CodeforcesTable } from "./components/CodeforcesTable.jsx";
 import { CodechefTable } from "./components/CodechefTable";
-import { GithubTable } from "./components/GithubTable";
+import { GithubTable, GHTable } from "./components/GithubTable";
 import Profile from "./components/Profile.jsx";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { OpenLakeTable } from "./components/OpenlakeTable";
@@ -155,14 +155,15 @@ function App() {
                   path="/github"
                   element={
                     <PrivateRoute>
-                      <GithubTable
+                      {/* <GithubTable
                         darkmode={darkmode}
                         githubUsers={githubUser}
                         githubfriends={githubfriends}
                         setGithubfriends={setGithubfriends}
                         ghshowfriends={ghshowfriends}
                         setGHshowfriends={setGhshowfriends}
-                      />
+                      /> */}
+                      <GHTable githubUsers={githubUser} />
                     </PrivateRoute>
                   }
                 />

--- a/app/src/components/GithubTable.jsx
+++ b/app/src/components/GithubTable.jsx
@@ -1,73 +1,14 @@
-import { styled } from "@mui/material/styles";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  Link,
-  Avatar,
-} from "@mui/material";
-import TextField from "@mui/material/TextField";
-import SearchIcon from "@mui/icons-material/Search";
-import InputAdornment from "@mui/material/InputAdornment";
 import { useEffect, useState } from "react";
-import ToggleButton from "@mui/material/ToggleButton";
-import Button from "@mui/material/Button";
 import { useSidebar } from "@/components/ui/sidebar";
-import { Button as NewButton } from "./ui/button";
+import { Button } from "./ui/button";
 import { DataTable } from "./ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Switch } from "./ui/switch";
 import {
-  Avatar as NewAvatar,
+  Avatar,
   AvatarFallback,
   AvatarImage,
 } from "@/components/ui/avatar";
-
-const PREFIX = "GithubTable";
-
-const classes = {
-  root: `${PREFIX}-root`,
-  table: `${PREFIX}-table`,
-  table_dark: `${PREFIX}-table_dark`,
-  medium_page: `${PREFIX}-medium_page`,
-  large_page: `${PREFIX}-large_page`,
-};
-
-const Root = styled("div")({
-  [`& .${classes.table}`]: {
-    minWidth: 500,
-  },
-  [`& .${classes.table_dark}`]: {
-    minWidth: 500,
-    backgroundColor: "Black",
-    border: "2px solid White",
-    borderRadius: "10px",
-  },
-  [`& .${classes.medium_page}`]: {
-    display: "flex",
-    justifyContent: "space-around",
-    flexDirection: "column-reverse",
-    paddingLeft: "2.5vw",
-    paddingRight: "2.5vw",
-    marginTop: "9vh",
-    width: "100vw",
-    flexShrink: "0",
-  },
-  [`& .${classes.large_page}`]: {
-    display: "flex",
-    justifyContent: "space-around",
-    flexDirection: "row",
-    padding: "auto",
-    marginTop: "10vh",
-    width: "99vw",
-    flexShrink: "0",
-  },
-});
-
 const BACKEND = import.meta.env.VITE_BACKEND;
 export function GHTable({ githubUsers }) {
   const [searchfield, setSearchfield] = useState("");
@@ -82,10 +23,10 @@ export function GHTable({ githubUsers }) {
       header: "Avatar",
       cell: ({ row }) => {
         return (
-          <NewAvatar>
+          <Avatar>
             <AvatarImage src={row.getValue("avatar")} />
-            <AvatarFallback>CN</AvatarFallback>
-          </NewAvatar>
+            <AvatarFallback>{row.getValue("username")}</AvatarFallback>
+          </Avatar>
         );
       },
     },
@@ -95,7 +36,7 @@ export function GHTable({ githubUsers }) {
       cell: ({ row }) => {
         const username = row.getValue("username");
         return (
-          <NewButton variant="link" asChild>
+          <Button variant="link" asChild>
             <a
               href={`https://github.com/${username}`}
               target="_blank"
@@ -103,7 +44,7 @@ export function GHTable({ githubUsers }) {
             >
               {username}
             </a>
-          </NewButton>
+          </Button>
         );
       },
     },
@@ -126,19 +67,19 @@ export function GHTable({ githubUsers }) {
         return (
           <div className="flex justify-end">
             {githubfriends.includes(username) ? (
-              <NewButton
+              <Button
                 variant="outline"
                 onClick={() => dropfriend(username)}
               >
                 Remove Friend
-              </NewButton>
+              </Button>
             ) : (
-              <NewButton
+              <Button
                 variant="secondary"
                 onClick={() => addfriend(username)}
               >
                 Add Friend
-              </NewButton>
+              </Button>
             )}
           </div>
         );
@@ -269,311 +210,3 @@ export function GHTable({ githubUsers }) {
     </div>
   );
 }
-
-export const GithubTable = ({
-  darkmode,
-  githubUsers,
-  githubfriends,
-  setGithubfriends,
-  ghshowfriends,
-  setGHshowfriends,
-}) => {
-  const [searchfield, setSearchfield] = useState("");
-  const [filteredusers, setFilteredusers] = useState([]);
-  const [todisplayusers, setTodisplayusers] = useState([]);
-  const { open, isMobile } = useSidebar();
-  const getghfriends = async () => {
-    const response = await fetch(BACKEND + "/githubFL/", {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Bearer " +
-          JSON.parse(localStorage.getItem("authTokens")).access,
-      },
-    });
-
-    const newData = await response.json();
-    setGithubfriends(newData);
-  };
-
-  async function addfriend(e) {
-    const response = await fetch(BACKEND + "/githubFA/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Bearer " +
-          JSON.parse(localStorage.getItem("authTokens")).access,
-      },
-      body: JSON.stringify({
-        friendName: e.username,
-      }),
-    });
-    if (response.status !== 200) {
-      alert("ERROR!!!!");
-    } else {
-      setGithubfriends((current) => [...current, e]);
-    }
-  }
-  async function dropfriend(e) {
-    const response = await fetch(BACKEND + "/githubFD/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Bearer " +
-          JSON.parse(localStorage.getItem("authTokens")).access,
-      },
-      body: JSON.stringify({
-        friendName: e,
-      }),
-    });
-    if (response.status !== 200) {
-      alert("ERROR!!!!");
-    } else {
-      setGithubfriends((current) =>
-        current.filter((fruit) => fruit.username !== e),
-      );
-    }
-  }
-  useEffect(() => {
-    getghfriends();
-  }, []);
-
-  useEffect(() => {
-    if (ghshowfriends) {
-      setTodisplayusers(githubfriends);
-    } else {
-      setTodisplayusers(githubUsers);
-    }
-    if (searchfield === "") {
-      setFilteredusers(todisplayusers);
-    } else {
-      setFilteredusers(
-        todisplayusers.filter((ghUser) => {
-          return ghUser.username
-            .toLowerCase()
-            .includes(searchfield.toLowerCase());
-        }),
-      );
-    }
-  }, [ghshowfriends, githubfriends, searchfield, githubUsers]);
-  useEffect(() => {
-    if (searchfield === "") {
-      setFilteredusers(todisplayusers);
-    } else {
-      setFilteredusers(
-        todisplayusers.filter((ghUser) => {
-          return ghUser.username
-            .toLowerCase()
-            .includes(searchfield.toLowerCase());
-        }),
-      );
-    }
-  }, [searchfield, todisplayusers]);
-
-  const StyledTableCell = TableCell;
-
-  return (
-    <Root
-      className={`codechef ${isMobile ? classes.medium_page : classes.large_page}`}
-    >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          marginTop: "15vh",
-          position: "relative",
-          marginBottom: "10px",
-          alignItems: "center",
-          width:
-            open && !isMobile
-              ? "calc(100vw - var(--sidebar-width))"
-              : "100vw",
-        }}
-      >
-        <TextField
-          id="outlined-basic"
-          label="Search Usernames"
-          variant="outlined"
-          defaultValue=""
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon />
-              </InputAdornment>
-            ),
-          }}
-          onChange={(e) => {
-            setSearchfield(e.target.value);
-          }}
-        />
-        <ToggleButton
-          value="check"
-          selected={ghshowfriends}
-          onChange={() => {
-            setGHshowfriends(!ghshowfriends);
-          }}
-          style={{
-            backgroundColor: darkmode ? "#02055a" : "#2196f3",
-            color: "white",
-            marginTop: isMobile ? "2vh" : "4vh",
-          }}
-        >
-          {ghshowfriends ? "Show All" : "Show Friends"}
-        </ToggleButton>
-        <div
-          style={{
-            marginTop: isMobile ? "2vh" : "4vh",
-          }}
-        >
-          {!filteredusers.length ? (
-            "No users"
-          ) : (
-            <TableContainer component={Paper}>
-              <Table
-                className={darkmode ? classes.table_dark : classes.table}
-                aria-label="github-table"
-              >
-                <TableHead>
-                  <TableRow
-                    style={{
-                      backgroundColor: darkmode ? "#1c2e4a" : "#1CA7FC",
-                    }}
-                  >
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Avatar
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Username
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Contributions
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Repositories
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Stars
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    ></StyledTableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {filteredusers
-                    .sort((a, b) =>
-                      a.contributions < b.contributions ? 1 : -1,
-                    )
-                    .map((glUser) => (
-                      <TableRow key={glUser.id}>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          <Avatar
-                            src={glUser.avatar}
-                            alt={`${glUser.username} avatar`}
-                          />
-                          {/* TODO: Lazy load the avatars ? */}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          <Link
-                            style={{
-                              fontWeight: "bold",
-                              textDecoration: "none",
-                              color: darkmode ? "#03DAC6" : "",
-                            }}
-                            href={`https://github.com/${glUser.username}`}
-                            target="_blank"
-                          >
-                            {glUser.username}
-                          </Link>
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          {glUser.contributions}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          {glUser.repositories}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          {glUser.stars}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          <Button
-                            variant="contained"
-                            style={{
-                              backgroundColor: darkmode ? "#146ca4" : "",
-                            }}
-                            onClick={() => {
-                              !githubfriends.some(
-                                (item) =>
-                                  item.username === glUser.username,
-                              )
-                                ? addfriend(glUser)
-                                : dropfriend(glUser.username);
-                            }}
-                          >
-                            {githubfriends.some(
-                              (item) => item.username === glUser.username,
-                            )
-                              ? "Remove Friend"
-                              : "Add Friend"}
-                          </Button>
-                        </StyledTableCell>
-                      </TableRow>
-                    ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
-        </div>
-      </div>
-    </Root>
-  );
-};

--- a/app/src/components/GithubTable.jsx
+++ b/app/src/components/GithubTable.jsx
@@ -17,6 +17,15 @@ import { useEffect, useState } from "react";
 import ToggleButton from "@mui/material/ToggleButton";
 import Button from "@mui/material/Button";
 import { useSidebar } from "@/components/ui/sidebar";
+import { Button as NewButton } from "./ui/button";
+import { DataTable } from "./ui/data-table";
+import { Input } from "@/components/ui/input";
+import { Switch } from "./ui/switch";
+import {
+  Avatar as NewAvatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
 
 const PREFIX = "GithubTable";
 
@@ -60,6 +69,206 @@ const Root = styled("div")({
 });
 
 const BACKEND = import.meta.env.VITE_BACKEND;
+export function GHTable({ githubUsers }) {
+  const [searchfield, setSearchfield] = useState("");
+  const [filteredusers, setFilteredusers] = useState([]);
+  const [todisplayusers, setTodisplayusers] = useState([]);
+  const [githubfriends, setGithubfriends] = useState([]);
+  const [ghshowfriends, setGHshowfriends] = useState(false);
+  const { open, isMobile } = useSidebar();
+  const columns = [
+    {
+      accessorKey: "avatar",
+      header: "Avatar",
+      cell: ({ row }) => {
+        return (
+          <NewAvatar>
+            <AvatarImage src={row.getValue("avatar")} />
+            <AvatarFallback>CN</AvatarFallback>
+          </NewAvatar>
+        );
+      },
+    },
+    {
+      accessorKey: "username",
+      header: "Username",
+      cell: ({ row }) => {
+        const username = row.getValue("username");
+        return (
+          <NewButton variant="link" asChild>
+            <a
+              href={`https://github.com/${username}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {username}
+            </a>
+          </NewButton>
+        );
+      },
+    },
+    {
+      accessorKey: "contributions",
+      header: "Contributions",
+    },
+    {
+      accessorKey: "repositories",
+      header: "Repositories",
+    },
+    {
+      accessorKey: "stars",
+      header: "Stars",
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => {
+        const username = row.getValue("username");
+        return (
+          <div className="flex justify-end">
+            {githubfriends.includes(username) ? (
+              <NewButton
+                variant="outline"
+                onClick={() => dropfriend(username)}
+              >
+                Remove Friend
+              </NewButton>
+            ) : (
+              <NewButton
+                variant="secondary"
+                onClick={() => addfriend(username)}
+              >
+                Add Friend
+              </NewButton>
+            )}
+          </div>
+        );
+      },
+    },
+  ];
+  const getghfriends = async () => {
+    const response = await fetch(BACKEND + "/githubFL/", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Bearer " +
+          JSON.parse(localStorage.getItem("authTokens")).access,
+      },
+    });
+
+    const newData = await response.json();
+    setGithubfriends(newData);
+  };
+
+  async function addfriend(e) {
+    const response = await fetch(BACKEND + "/githubFA/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Bearer " +
+          JSON.parse(localStorage.getItem("authTokens")).access,
+      },
+      body: JSON.stringify({
+        friendName: e,
+      }),
+    });
+    if (response.status !== 200) {
+      alert("ERROR!!!!");
+    } else {
+      setGithubfriends((current) => [...current, e]);
+    }
+  }
+  async function dropfriend(e) {
+    const response = await fetch(BACKEND + "/githubFD/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Bearer " +
+          JSON.parse(localStorage.getItem("authTokens")).access,
+      },
+      body: JSON.stringify({
+        friendName: e,
+      }),
+    });
+    if (response.status !== 200) {
+      alert("ERROR!!!!");
+    } else {
+      setGithubfriends((current) =>
+        current.filter((fruit) => fruit.username !== e),
+      );
+    }
+  }
+  useEffect(() => {
+    getghfriends();
+  }, []);
+
+  useEffect(() => {
+    if (ghshowfriends) {
+      setTodisplayusers(githubfriends);
+    } else {
+      setTodisplayusers(githubUsers);
+    }
+    if (searchfield === "") {
+      setFilteredusers(todisplayusers);
+    } else {
+      setFilteredusers(
+        todisplayusers.filter((ghUser) => {
+          return ghUser.username
+            .toLowerCase()
+            .includes(searchfield.toLowerCase());
+        }),
+      );
+    }
+  }, [ghshowfriends, githubfriends, searchfield, githubUsers]);
+  useEffect(() => {
+    if (searchfield === "") {
+      setFilteredusers(todisplayusers);
+    } else {
+      setFilteredusers(
+        todisplayusers.filter((ghUser) => {
+          return ghUser.username
+            .toLowerCase()
+            .includes(searchfield.toLowerCase());
+        }),
+      );
+    }
+  }, [searchfield, todisplayusers]);
+  return (
+    <div
+      className="h-full px-1.5 py-1"
+      style={{
+        width:
+          open && !isMobile
+            ? "calc(100vw - var(--sidebar-width))"
+            : "100vw",
+      }}
+    >
+      <div className="mb-2 flex flex-row justify-between">
+        <Input
+          placeholder="Search Github contributors..."
+          className="w-[40%]"
+          onChange={(val) => setSearchfield(val.target.value)}
+          type="search"
+        />
+        <div>
+          Friends Only
+          <Switch
+            className="mx-1 align-middle"
+            onCheckedChange={(val) => setGHshowfriends(val)}
+          />
+        </div>
+      </div>
+      <DataTable
+        data={filteredusers.sort((a, b) =>
+          a.contributions < b.contributions ? 1 : -1,
+        )}
+        columns={columns}
+      />
+    </div>
+  );
+}
 
 export const GithubTable = ({
   darkmode,


### PR DESCRIPTION
## Purpose ✨

<!--- Mention the purpose of the PR --->
This PR intends to migrate the Github contributions leaderboard from being based on Material UI to ShadCN. Part of #132 
## Details 📝

<!--- Mention the details. If the details sections is large enough, then mention the details in bullets as follows: --->

- Migrate the GithubTable Component to ShadCN changing its name to GHTable.

## Dependencies 🔗

None

## Future Improvements 🔭
None

## Mentions 👀
@amaydixit11 
<!--- Mention and tag the people. Type '@' and you will automatically get suggestions. Usually the mentions are for the person(s) by whom you wanted your PR to get reviewed. --->

## Screenshots of relevant screens 📸
- ### Dark Mode<img width="1851" height="902" alt="image" src="https://github.com/user-attachments/assets/2b015fe5-f70b-427f-aaf7-b09894306702" />
- ### Light Mode<img width="1851" height="902" alt="image" src="https://github.com/user-attachments/assets/f1803bb7-0a4d-4851-97bb-be8a93df87e6" />

