### PR TITLE
[DEVLABS-2025] Migrate from Material UI to ShadCN (CodeforcesTable to CFtable)

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from "react";
 import "./App.css";
 import { Navbar } from "./components/Navbar.jsx";
-import { CodeforcesTable } from "./components/CodeforcesTable.jsx";
+import {
+  CFTable,
+  CodeforcesTable,
+} from "./components/CodeforcesTable.jsx";
 import { CodechefTable } from "./components/CodechefTable";
 import { GHTable } from "./components/GithubTable";
 import Profile from "./components/Profile.jsx";
@@ -110,14 +113,15 @@ function App() {
                   path="/codeforces"
                   element={
                     <PrivateRoute>
-                      <CodeforcesTable
+                      {/* <CodeforcesTable
                         darkmode={darkmode}
                         codeforcesfriends={codeforcesfriends}
                         setCodeforcesfriends={setCodeforcesfriends}
                         codeforcesUsers={codeforcesUsers}
                         cfshowfriends={cfshowfriends}
                         setCfshowfriends={setCfshowfriends}
-                      />
+                      /> */}
+                      <CFTable codeforcesUsers={codeforcesUsers} />
                     </PrivateRoute>
                   }
                 />

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,10 +1,7 @@
 import React, { useState, useEffect } from "react";
 import "./App.css";
 import { Navbar } from "./components/Navbar.jsx";
-import {
-  CFTable,
-  CodeforcesTable,
-} from "./components/CodeforcesTable.jsx";
+import { CFTable } from "./components/CodeforcesTable.jsx";
 import { CodechefTable } from "./components/CodechefTable";
 import { GHTable } from "./components/GithubTable";
 import Profile from "./components/Profile.jsx";
@@ -33,8 +30,6 @@ function App() {
   const [leetcodeUsers, setLeetcodeUsers] = useState([]);
   const [openlakeContributor, setOpenlakeContributor] = useState([]);
   const [githubUser, setGithubUser] = useState([]);
-  const [codeforcesfriends, setCodeforcesfriends] = useState([]);
-  const [cfshowfriends, setCfshowfriends] = useState(false);
   const [ccshowfriends, setCCshowfriends] = useState(false);
   const [codecheffriends, setCodecheffriends] = useState([]);
   useEffect(() => {
@@ -113,14 +108,6 @@ function App() {
                   path="/codeforces"
                   element={
                     <PrivateRoute>
-                      {/* <CodeforcesTable
-                        darkmode={darkmode}
-                        codeforcesfriends={codeforcesfriends}
-                        setCodeforcesfriends={setCodeforcesfriends}
-                        codeforcesUsers={codeforcesUsers}
-                        cfshowfriends={cfshowfriends}
-                        setCfshowfriends={setCfshowfriends}
-                      /> */}
                       <CFTable codeforcesUsers={codeforcesUsers} />
                     </PrivateRoute>
                   }

--- a/app/src/components/CodeforcesTable.jsx
+++ b/app/src/components/CodeforcesTable.jsx
@@ -225,7 +225,7 @@ export function CFTable({ codeforcesUsers }) {
     >
       <div className="mb-2 flex flex-row justify-between">
         <Input
-          placeholder="Search Leetcode users..."
+          placeholder="Search Codeforces users..."
           className="w-[40%]"
           onChange={(val) => setSearchfield(val.target.value)}
           type="search"
@@ -239,9 +239,7 @@ export function CFTable({ codeforcesUsers }) {
         </div>
       </div>
       <DataTable
-        data={filteredusers.sort((a, b) =>
-          a.contributions < b.contributions ? 1 : -1,
-        )}
+        data={filteredusers.sort((a, b) => (a.rating < b.rating ? 1 : -1))}
         columns={columns}
       />
     </div>

--- a/app/src/components/CodeforcesTable.jsx
+++ b/app/src/components/CodeforcesTable.jsx
@@ -1,73 +1,15 @@
-import { styled } from "@mui/material/styles";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  Link,
-  Avatar,
-} from "@mui/material";
-import TextField from "@mui/material/TextField";
-import SearchIcon from "@mui/icons-material/Search";
-import InputAdornment from "@mui/material/InputAdornment";
 import { useEffect, useState } from "react";
-import ToggleButton from "@mui/material/ToggleButton";
-import Button from "@mui/material/Button";
 import { useSidebar } from "@/components/ui/sidebar";
-import { Button as NewButton } from "./ui/button";
+import { Button } from "./ui/button";
 import { DataTable } from "./ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Switch } from "./ui/switch";
 import {
-  Avatar as NewAvatar,
+  Avatar,
   AvatarFallback,
   AvatarImage,
 } from "@/components/ui/avatar";
 import { User } from "lucide-react";
-
-const PREFIX = "CodeforcesTable";
-
-const classes = {
-  root: `${PREFIX}-root`,
-  table: `${PREFIX}-table`,
-  table_dark: `${PREFIX}-table_dark`,
-  medium_page: `${PREFIX}-medium_page`,
-  large_page: `${PREFIX}-large_page`,
-};
-
-const Root = styled("div")({
-  [`& .${classes.table}`]: {
-    minWidth: 650,
-  },
-  [`& .${classes.table_dark}`]: {
-    minWidth: 650,
-    backgroundColor: "Black",
-    border: "2px solid White",
-    borderRadius: "10px",
-  },
-  [`& .${classes.medium_page}`]: {
-    display: "flex",
-    justifyContent: "space-around",
-    flexDirection: "column-reverse",
-    paddingLeft: "2.5vw",
-    paddingRight: "2.5vw",
-    marginTop: "9vh",
-    width: "100vw",
-    flexShrink: "0",
-  },
-  [`& .${classes.large_page}`]: {
-    display: "flex",
-    justifyContent: "space-around",
-    flexDirection: "row",
-    padding: "auto",
-    marginTop: "10vh",
-    width: "99vw",
-    flexShrink: "0",
-  },
-});
 
 const BACKEND = import.meta.env.VITE_BACKEND;
 
@@ -84,12 +26,12 @@ export function CFTable({ codeforcesUsers }) {
       header: "Avatar",
       cell: ({ row }) => {
         return (
-          <NewAvatar>
+          <Avatar>
             <AvatarImage src={row.getValue("avatar")} />
             <AvatarFallback>
               <User />
             </AvatarFallback>
-          </NewAvatar>
+          </Avatar>
         );
       },
     },
@@ -99,7 +41,7 @@ export function CFTable({ codeforcesUsers }) {
       cell: ({ row }) => {
         const username = row.getValue("username");
         return (
-          <NewButton variant="link" asChild>
+          <Button variant="link" asChild>
             <a
               href={`https://codeforces.com/profile/${username}`}
               target="_blank"
@@ -107,7 +49,7 @@ export function CFTable({ codeforcesUsers }) {
             >
               {username}
             </a>
-          </NewButton>
+          </Button>
         );
       },
     },
@@ -135,19 +77,19 @@ export function CFTable({ codeforcesUsers }) {
         return (
           <div className="flex justify-end">
             {codeforcesfriends.includes(username) ? (
-              <NewButton
+              <Button
                 variant="outline"
                 onClick={() => dropfriend(username)}
               >
                 Remove Friend
-              </NewButton>
+              </Button>
             ) : (
-              <NewButton
+              <Button
                 variant="secondary"
                 onClick={() => addfriend(username)}
               >
                 Add Friend
-              </NewButton>
+              </Button>
             )}
           </div>
         );
@@ -305,352 +247,3 @@ export function CFTable({ codeforcesUsers }) {
     </div>
   );
 }
-export const CodeforcesTable = ({
-  darkmode,
-  codeforcesUsers,
-  codeforcesfriends,
-  setCodeforcesfriends,
-  cfshowfriends,
-  setCfshowfriends,
-}) => {
-  const [searchfield, setSearchfield] = useState("");
-  const [filteredusers, setFilteredusers] = useState([]);
-  const [todisplayusers, setTodisplayusers] = useState([]);
-  const { open, isMobile } = useSidebar();
-  const getcffriends = async () => {
-    const response = await fetch(BACKEND + "/codeforcesFL/", {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Bearer " +
-          JSON.parse(localStorage.getItem("authTokens")).access,
-      },
-    });
-    const newData = await response.json();
-    setCodeforcesfriends(newData);
-  };
-
-  async function addfriend(e) {
-    const response = await fetch(BACKEND + "/codeforcesFA/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Bearer " +
-          JSON.parse(localStorage.getItem("authTokens")).access,
-      },
-      body: JSON.stringify({
-        friendName: e.username,
-      }),
-    });
-    if (response.status !== 200) {
-      alert("ERROR!!!!");
-    } else {
-      setCodeforcesfriends((current) => [...current, e]);
-    }
-  }
-  async function dropfriend(e) {
-    const response = await fetch(BACKEND + "/codeforcesFD/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Bearer " +
-          JSON.parse(localStorage.getItem("authTokens")).access,
-      },
-      body: JSON.stringify({
-        friendName: e,
-      }),
-    });
-    if (response.status !== 200) {
-      alert("ERROR!!!!");
-    } else {
-      setCodeforcesfriends((current) =>
-        current.filter((fruit) => fruit.username !== e),
-      );
-    }
-  }
-  useEffect(() => {
-    getcffriends();
-  }, []);
-
-  useEffect(() => {
-    if (cfshowfriends) {
-      setTodisplayusers(codeforcesfriends);
-    } else {
-      setTodisplayusers(codeforcesUsers);
-    }
-    if (searchfield === "") {
-      setFilteredusers(todisplayusers);
-    } else {
-      setFilteredusers(
-        todisplayusers.filter((cfUser) => {
-          return cfUser.username
-            .toLowerCase()
-            .includes(searchfield.toLowerCase());
-        }),
-      );
-    }
-  }, [cfshowfriends, codeforcesfriends, searchfield, codeforcesUsers]);
-  useEffect(() => {
-    if (searchfield === "") {
-      setFilteredusers(todisplayusers);
-    } else {
-      setFilteredusers(
-        todisplayusers.filter((cfUser) => {
-          return cfUser.username
-            .toLowerCase()
-            .includes(searchfield.toLowerCase());
-        }),
-      );
-    }
-  }, [searchfield, todisplayusers]);
-  const StyledTableCell = TableCell;
-
-  function timeConverter(UNIX_timestamp) {
-    var a = new Date(UNIX_timestamp * 1000);
-    var months = [
-      "Jan",
-      "Feb",
-      "Mar",
-      "Apr",
-      "May",
-      "Jun",
-      "Jul",
-      "Aug",
-      "Sep",
-      "Oct",
-      "Nov",
-      "Dec",
-    ];
-    var year = a.getFullYear();
-    var month = months[a.getMonth()];
-    var date = a.getDate();
-    var hour = a.getHours();
-    var min = a.getMinutes();
-    var sec = a.getSeconds();
-    var time =
-      date + " " + month + " " + year + " " + hour + ":" + min + ":" + sec;
-    return time;
-  }
-
-  // const isMobile = useScreenWidth(786);
-
-  return (
-    <Root
-      className={`codechef ${isMobile ? classes.medium_page : classes.large_page}`}
-    >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          marginTop: "15vh",
-          position: "relative",
-          marginBottom: "10px",
-          alignItems: "center",
-          width:
-            open && !isMobile
-              ? "calc(100vw - var(--sidebar-width))"
-              : "100vw",
-        }}
-      >
-        <TextField
-          id="outlined-basic"
-          label="Search Usernames"
-          variant="outlined"
-          defaultValue=""
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon />
-              </InputAdornment>
-            ),
-          }}
-          onChange={(e) => {
-            setSearchfield(e.target.value);
-          }}
-        />
-        <ToggleButton
-          value="check"
-          selected={cfshowfriends}
-          onChange={() => {
-            setCfshowfriends(!cfshowfriends);
-          }}
-          style={{
-            backgroundColor: darkmode ? "#02055a" : "#2196f3",
-            color: "white",
-            marginTop: isMobile ? "2vh" : "4vh",
-          }}
-        >
-          {cfshowfriends ? "Show All" : "Show Friends"}
-        </ToggleButton>
-        <div
-          style={{
-            marginTop: isMobile ? "2vh" : "4vh",
-          }}
-        >
-          {!filteredusers.length ? (
-            "No users"
-          ) : (
-            <TableContainer component={Paper}>
-              <Table
-                className={darkmode ? classes.table_dark : classes.table}
-                aria-label="codeforces-table"
-              >
-                <TableHead>
-                  <TableRow
-                    style={{
-                      backgroundColor: darkmode ? "#1c2e4a" : "#1CA7FC",
-                    }}
-                  >
-                    {/* #1CA7FC */}
-                    {/* #1F2F98 */}
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Avatar
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Username
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Rating
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Max rating
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Last activity
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    >
-                      Total Solved
-                    </StyledTableCell>
-                    <StyledTableCell
-                      classes={{
-                        root: classes.root,
-                      }}
-                    ></StyledTableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {filteredusers
-                    .sort((a, b) => (a.rating < b.rating ? 1 : -1))
-                    .map((cfUser) => (
-                      <TableRow key={cfUser.id}>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          <Avatar
-                            src={cfUser.avatar}
-                            alt={`${cfUser.username} avatar`}
-                          />
-                          {/* TODO: Lazy load the avatars ? */}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          <Link
-                            style={{
-                              fontWeight: "bold",
-                              textDecoration: "none",
-                              color: darkmode ? "#03DAC6" : "",
-                            }}
-                            href={`https://codeforces.com/profile/${cfUser.username}`}
-                            target="_blank"
-                          >
-                            {cfUser.username}
-                          </Link>
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          {cfUser.rating}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          {cfUser.max_rating}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          {timeConverter(cfUser.last_activity)}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          {cfUser.total_solved}
-                        </StyledTableCell>
-                        <StyledTableCell
-                          classes={{
-                            root: classes.root,
-                          }}
-                        >
-                          <Button
-                            variant="contained"
-                            style={{
-                              backgroundColor: darkmode ? "#146ca4" : "",
-                            }}
-                            onClick={() => {
-                              Array.isArray(codeforcesUsers) &&
-                              !codeforcesfriends.some(
-                                (item) =>
-                                  item.username === cfUser.username,
-                              )
-                                ? addfriend(cfUser)
-                                : dropfriend(cfUser.username);
-                            }}
-                          >
-                            {codeforcesfriends.some(
-                              (item) => item.username === cfUser.username,
-                            )
-                              ? "Remove Friend"
-                              : "Add Friend"}
-                          </Button>
-                        </StyledTableCell>
-                      </TableRow>
-                    ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
-        </div>
-      </div>
-    </Root>
-  );
-};

--- a/app/src/components/CodeforcesTable.jsx
+++ b/app/src/components/CodeforcesTable.jsx
@@ -17,6 +17,16 @@ import { useEffect, useState } from "react";
 import ToggleButton from "@mui/material/ToggleButton";
 import Button from "@mui/material/Button";
 import { useSidebar } from "@/components/ui/sidebar";
+import { Button as NewButton } from "./ui/button";
+import { DataTable } from "./ui/data-table";
+import { Input } from "@/components/ui/input";
+import { Switch } from "./ui/switch";
+import {
+  Avatar as NewAvatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import { User } from "lucide-react";
 
 const PREFIX = "CodeforcesTable";
 
@@ -61,6 +71,240 @@ const Root = styled("div")({
 
 const BACKEND = import.meta.env.VITE_BACKEND;
 
+export function CFTable({ codeforcesUsers }) {
+  const [searchfield, setSearchfield] = useState("");
+  const [filteredusers, setFilteredusers] = useState([]);
+  const [todisplayusers, setTodisplayusers] = useState([]);
+  const { open, isMobile } = useSidebar();
+  const [codeforcesfriends, setCodeforcesfriends] = useState([]);
+  const [cfshowfriends, setCfshowfriends] = useState(false);
+  const columns = [
+    {
+      accessorKey: "avatar",
+      header: "Avatar",
+      cell: ({ row }) => {
+        return (
+          <NewAvatar>
+            <AvatarImage src={row.getValue("avatar")} />
+            <AvatarFallback>
+              <User />
+            </AvatarFallback>
+          </NewAvatar>
+        );
+      },
+    },
+    {
+      accessorKey: "username",
+      header: "Username",
+      cell: ({ row }) => {
+        const username = row.getValue("username");
+        return (
+          <NewButton variant="link" asChild>
+            <a
+              href={`https://codeforces.com/profile/${username}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {username}
+            </a>
+          </NewButton>
+        );
+      },
+    },
+    {
+      accessorKey: "rating",
+      header: "Rating",
+    },
+    {
+      accessorKey: "max_rating",
+      header: "Max Rating",
+    },
+    {
+      accessorKey: "last_activity",
+      header: "Last Activity",
+      cell: ({ row }) => timeConverter(row.getValue("last_activity")),
+    },
+    {
+      accessorKey: "total_solved",
+      header: "Total solved",
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => {
+        const username = row.getValue("username");
+        return (
+          <div className="flex justify-end">
+            {codeforcesfriends.includes(username) ? (
+              <NewButton
+                variant="outline"
+                onClick={() => dropfriend(username)}
+              >
+                Remove Friend
+              </NewButton>
+            ) : (
+              <NewButton
+                variant="secondary"
+                onClick={() => addfriend(username)}
+              >
+                Add Friend
+              </NewButton>
+            )}
+          </div>
+        );
+      },
+    },
+  ];
+
+  const getcffriends = async () => {
+    const response = await fetch(BACKEND + "/codeforcesFL/", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Bearer " +
+          JSON.parse(localStorage.getItem("authTokens")).access,
+      },
+    });
+    const newData = await response.json();
+    setCodeforcesfriends(newData);
+  };
+
+  async function addfriend(e) {
+    const response = await fetch(BACKEND + "/codeforcesFA/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Bearer " +
+          JSON.parse(localStorage.getItem("authTokens")).access,
+      },
+      body: JSON.stringify({
+        friendName: e,
+      }),
+    });
+    if (response.status !== 200) {
+      alert("ERROR!!!!");
+    } else {
+      setCodeforcesfriends((current) => [...current, e]);
+    }
+  }
+  async function dropfriend(e) {
+    const response = await fetch(BACKEND + "/codeforcesFD/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Bearer " +
+          JSON.parse(localStorage.getItem("authTokens")).access,
+      },
+      body: JSON.stringify({
+        friendName: e,
+      }),
+    });
+    if (response.status !== 200) {
+      alert("ERROR!!!!");
+    } else {
+      setCodeforcesfriends((current) =>
+        current.filter((fruit) => fruit.username !== e),
+      );
+    }
+  }
+  useEffect(() => {
+    getcffriends();
+  }, []);
+
+  useEffect(() => {
+    if (cfshowfriends) {
+      setTodisplayusers(codeforcesfriends);
+    } else {
+      setTodisplayusers(codeforcesUsers);
+    }
+    if (searchfield === "") {
+      setFilteredusers(todisplayusers);
+    } else {
+      setFilteredusers(
+        todisplayusers.filter((cfUser) => {
+          return cfUser.username
+            .toLowerCase()
+            .includes(searchfield.toLowerCase());
+        }),
+      );
+    }
+  }, [cfshowfriends, codeforcesfriends, searchfield, codeforcesUsers]);
+  useEffect(() => {
+    if (searchfield === "") {
+      setFilteredusers(todisplayusers);
+    } else {
+      setFilteredusers(
+        todisplayusers.filter((cfUser) => {
+          return cfUser.username
+            .toLowerCase()
+            .includes(searchfield.toLowerCase());
+        }),
+      );
+    }
+  }, [searchfield, todisplayusers]);
+
+  function timeConverter(UNIX_timestamp) {
+    var a = new Date(UNIX_timestamp * 1000);
+    var months = [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ];
+    var year = a.getFullYear();
+    var month = months[a.getMonth()];
+    var date = a.getDate();
+    var hour = a.getHours().toString().padStart(2, "0");
+    var min = a.getMinutes().toString().padStart(2, "0");
+    var sec = a.getSeconds().toString().padStart(2, "0");
+    var time =
+      date + " " + month + " " + year + " " + hour + ":" + min + ":" + sec;
+    return time;
+  }
+  return (
+    <div
+      className="h-full px-1.5 py-1"
+      style={{
+        width:
+          open && !isMobile
+            ? "calc(100vw - var(--sidebar-width))"
+            : "100vw",
+      }}
+    >
+      <div className="mb-2 flex flex-row justify-between">
+        <Input
+          placeholder="Search Leetcode users..."
+          className="w-[40%]"
+          onChange={(val) => setSearchfield(val.target.value)}
+          type="search"
+        />
+        <div>
+          Friends Only
+          <Switch
+            className="mx-1 align-middle"
+            onCheckedChange={(val) => setCfshowfriends(val)}
+          />
+        </div>
+      </div>
+      <DataTable
+        data={filteredusers.sort((a, b) =>
+          a.contributions < b.contributions ? 1 : -1,
+        )}
+        columns={columns}
+      />
+    </div>
+  );
+}
 export const CodeforcesTable = ({
   darkmode,
   codeforcesUsers,


### PR DESCRIPTION
## Purpose ✨

<!--- Mention the purpose of the PR --->
This PR intends to migrate the Codeforces leaderboard from being based on Material UI to ShadCN. Part of #132 
## Details 📝

<!--- Mention the details. If the details sections is large enough, then mention the details in bullets as follows: --->

- Migrate the CodeforcesTable Component to ShadCN changing its name to GHTable.

## Dependencies 🔗

None

## Future Improvements 🔭
None

## Mentions 👀
@amaydixit11 
<!--- Mention and tag the people. Type '@' and you will automatically get suggestions. Usually the mentions are for the person(s) by whom you wanted your PR to get reviewed. --->

## Screenshots of relevant screens 📸
- ### Dark Mode<img width="1851" height="952" alt="image" src="https://github.com/user-attachments/assets/1ed234c5-f26b-4540-b31e-d69353ff6218" />
- ### Light Mode<img width="1851" height="952" alt="image" src="https://github.com/user-attachments/assets/b83da5f8-311c-4727-9621-c20d7d69acc0" />

