### PR TITLE
fix: correct friend removal logic in all leaderboard tables Fixes #162

### DIFF
--- a/app/src/components/CodechefTable.jsx
+++ b/app/src/components/CodechefTable.jsx
@@ -146,7 +146,7 @@ export function CCTable({ codechefUsers }) {
       alert("ERROR!!!!");
     } else {
       setCodecheffriends((current) =>
-        current.filter((fruit) => fruit.username !== e),
+        current.filter((fruit) => fruit !== e),
       );
     }
   }

--- a/app/src/components/CodeforcesTable.jsx
+++ b/app/src/components/CodeforcesTable.jsx
@@ -147,7 +147,7 @@ export function CFTable({ codeforcesUsers }) {
       alert("ERROR!!!!");
     } else {
       setCodeforcesfriends((current) =>
-        current.filter((fruit) => fruit.username !== e),
+        current.filter((fruit) => fruit !== e),
       );
     }
   }

--- a/app/src/components/GithubTable.jsx
+++ b/app/src/components/GithubTable.jsx
@@ -137,7 +137,7 @@ export function GHTable({ githubUsers }) {
       alert("ERROR!!!!");
     } else {
       setGithubfriends((current) =>
-        current.filter((fruit) => fruit.username !== e),
+         current.filter((fruit) => fruit !== e),
       );
     }
   }

--- a/app/src/components/LeetcodeTable.jsx
+++ b/app/src/components/LeetcodeTable.jsx
@@ -149,7 +149,7 @@ export function LCTable({ leetcodeUsers }) {
       alert("ERROR!!!!");
     } else {
       setLeetcodefriends((current) =>
-        current.filter((fruit) => fruit.username !== e),
+         current.filter((fruit) => fruit !== e),
       );
     }
   }

--- a/app/src/components/OpenlakeTable.jsx
+++ b/app/src/components/OpenlakeTable.jsx
@@ -113,7 +113,7 @@ export function OpenLakeTable({ OLUsers }) {
       alert("ERROR!!!!");
     } else {
       setOLFriends((current) =>
-        current.filter((fruit) => fruit.username !== e),
+         current.filter((fruit) => fruit !== e),
       );
     }
   }


### PR DESCRIPTION
I found the bug Fixes #162 ! The issue is in the friends state structure mismatch.

  Root Cause

  In all leaderboard components, the friends list from the API returns an array of username strings, but the
  dropfriend function is incorrectly trying to filter by fruit.username when the array only contains strings, not
  objects.

  Affected Files:

  1. OpenlakeTable.jsx:116 - uses fruit.username instead of just comparing the string
  2. LeetcodeTable.jsx:152 - uses fruit.username instead of just comparing the string
  3. GithubTable.jsx:140 - uses fruit.username instead of just comparing the string
  4. CodeforcesTable.jsx:150 - uses fruit.username instead of just comparing the string
  5. CodechefTable.jsx:149 - uses fruit.username instead of just comparing the string

  The friends arrays contain simple strings like ["user1", "user2"], but the filter logic treats them as objects
  with a .username property.