### PR TITLE
 fix: update OpenLake leaderboard refresh interval to 10 minutes #158

### DIFF
--- a/api/leaderboard/settings.py
+++ b/api/leaderboard/settings.py
@@ -230,7 +230,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles_build", "static")
 
 CC_INTV = 5
 GH_INTV = 10
-OL_INTV = 60
+OL_INTV = 10
 LT_INTV = 5
 CF_INTV = 5
 


### PR DESCRIPTION
Fixes #158 
Issue Found and Fixed

  Root cause: In api/leaderboard/settings.py:233, the OpenLake update interval (OL_INTV) was set to 60 minutes,
  which is 6x slower than GitHub's 10-minute interval.

 Fix applied: Changed OL_INTV from 60 to 10 minutes to match the GitHub update frequency. The OpenLake leaderboard
  will now refresh every 10 minutes instead of hourly.

  After restarting your Celery worker and beat scheduler, the OpenLake leaderboard should update at the same
  frequency as the GitHub contributions dashboard.
