### PR TITLE
fix: correct LeetCode profile link replacing github.com with leetcode…

### DIFF
--- a/app/src/components/LeetcodeTable.jsx
+++ b/app/src/components/LeetcodeTable.jsx
@@ -41,7 +41,7 @@ export function LCTable({ leetcodeUsers }) {
         return (
           <Button variant="link" asChild>
             <a
-              href={`https://github.com/${username}`}
+              href={`https://leetcode.com/u/${username}`}
               target="_blank"
               rel="noreferrer"
             >


### PR DESCRIPTION
….com/u

## Description

Replaced incorrect GitHub URL with the proper LeetCode user URL (leetcode.com/u/<username>).
This fixes the issue where clicking on the LeetCode username redirected users to GitHub instead of LeetCode.

## Related Issue(s)

- Fixes #168 
- Related to #168 

## Changes

- Updated frontend link logic for LeetCode profile

- Changed https://github.com/${username} →  @https://leetcode.com/u/${username}

- Verified link redirection works properly

## Screenshots of relevant screens 📸

none

## Type of Change

- [ ✔️] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor

## Checklist

- [ ✔️] Code follows project style
- [ ✔️] Tested locally
- [ ✔️] Docs updated (if needed)
- [✔️ ] No new warnings

## Notes

<!-- Extra context for reviewers. -->
