### PR TITLE
fix: add logo redirect to home in navbar (#159)

### DIFF
--- a/app/src/components/Navbar.jsx
+++ b/app/src/components/Navbar.jsx
@@ -77,11 +77,15 @@ export const Navbar = () => {
   return (
     <Sidebar>
       <SidebarHeader className="flex-row justify-between">
-        <Link to="/" className="flex items-center gap-2 font-semibold">
-         <Openlake className="h-6 w-6" />
-         <span>Leaderboard Pro</span>
-        </Link>
+        <Link
+          to="/"
+          className="flex items-center gap-2"
+          aria-label="Leaderboard Pro Home"
+          title="Leaderboard Pro">
+         <Openlake className="h-7 w-7" />
+       </Link>
      </SidebarHeader>
+
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupLabel className="text-xl font-extrabold">


### PR DESCRIPTION
## Description
Added the OpenLake logo in the sidebar header and made the logo/title clickable to redirect users to the home route.

## Related Issue(s)
- Fixes #159

## Changes
- Added OpenLake logo in `SidebarHeader`
- Wrapped logo/title with React Router `<Link>` for home navigation
- Improved alignment of header elements using flex utilities

## Screenshots of relevant screens 📸
<img width="320" height="685" alt="Screenshot 2026-01-22 110305" src="https://github.com/user-attachments/assets/a4fa4f27-4b1d-438b-9e1a-88952fe1fa3f" />

## Type of Change
- [x] Feature

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Navbar header is now an interactive link showing the Openlake icon (visible text removed) and includes accessible labeling (aria-label/title set to "Leaderboard Pro") to preserve branding and navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->