### PR TITLE
Fix evaluated default timestamp in codeforcesUser model

### DIFF
--- a/api/leaderboard/models.py
+++ b/api/leaderboard/models.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 from django.contrib.auth.models import AbstractUser
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-
+from django.utils.timezone import now
 
 class User(AbstractUser):
     uid = models.CharField(max_length=64, unique=True, null=True, blank=True)
@@ -51,7 +51,7 @@ class codeforcesUser(models.Model):
     username = models.CharField(max_length=64, unique=True)
     max_rating = models.PositiveIntegerField(default=0)
     rating = models.PositiveIntegerField(default=0)
-    last_activity = models.BigIntegerField(default=datetime.now().timestamp())
+    last_activity = models.BigIntegerField(default=lambda: int(now().timestamp()))
     last_updated = models.DateTimeField(auto_now=True)
     avatar = models.CharField(max_length=256, default="")
     total_solved = models.PositiveIntegerField(default=0)


### PR DESCRIPTION
## 🐛 Fix evaluated default timestamp in codeforcesUser.last_activity

### Problem
The `last_activity` field was using:

default=datetime.now().timestamp()

This value is evaluated at server startup, causing all new `codeforcesUser` instances to receive the same static timestamp until server restart.

### Solution
Replaced it with a callable:

default=lambda: int(now().timestamp())

This ensures a fresh, correct timestamp is generated at object creation time using Django’s timezone-aware utility.

### Impact
- Fixes incorrect default timestamp behavior
- Improves activity tracking accuracy
- No schema changes required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed timezone handling for user activity timestamps to ensure accurate tracking with timezone-aware data instead of naive timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->