### PR TITLE
Refactor is_outdated properties for consistent boolean return

### DIFF
--- a/api/leaderboard/models.py
+++ b/api/leaderboard/models.py
@@ -19,10 +19,7 @@ class githubUser(models.Model):
 
     @property
     def is_outdated(self):
-        if datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=1):
-            return True
-        else:
-            return False
+        return datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=1)
 
     def __str__(self):
         return f"{self.username}"
@@ -35,10 +32,7 @@ class openlakeContributor(models.Model):
 
     @property
     def is_outdated(self):
-        if datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=1):
-            return True
-        else:
-            return False
+        return datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=1)
 
     def __str__(self):
         return f"{self.username}"
@@ -59,10 +53,7 @@ class codeforcesUser(models.Model):
 
     @property
     def is_outdated(self):
-        if datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=1):
-            return True
-        else:
-            False
+        return datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=1)
 
     def __str__(self):
         return f"{self.username} ({self.rating})"
@@ -82,10 +73,7 @@ class codechefUser(models.Model):
 
     @property
     def is_outdated(self):
-        if datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=3):
-            return True
-        else:
-            False
+        return datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=3)
 
     def __str__(self):
         return f"{self.username} ({self.rating})"
@@ -129,10 +117,7 @@ class LeetcodeUser(models.Model):
 
     @property
     def is_outdated(self):
-        if datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=1):
-            return True
-        else:
-            return False
+        return datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=1)
 
     def __str__(self):
         return f"{self.username}"


### PR DESCRIPTION
## Description

## Refactor is_outdated properties for consistent boolean return

### Problem
Several `is_outdated` properties returned `None` when the condition was false due to using `else: False` without an explicit return statement.

### Solution
Refactored all `is_outdated` methods to directly return the boolean expression:

return datetime.now(tz=timezone.utc) - self.last_updated > timedelta(minutes=X)

### Impact
- Ensures consistent boolean return values
- Removes implicit None returns
- Improves readability and code clarity
- No functional behavior change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for consistency and maintainability across leaderboard data models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->